### PR TITLE
refactor: change "fragment" to "Fragment" to allow both usages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export const SSR = ssr
 
 export const Plugin = {
   install: function(Vue) {
-    Vue.component('fragment', component)
+    Vue.component('Fragment', component)
   }
 }
 


### PR DESCRIPTION
When registering a component with a kebab-case name then we could use it only with kebab-case, but if we register it using PascalCase then both kebab-case and PascalCase usages would work, like so:
<fragment></fragment>
<Fragment></Fragment>